### PR TITLE
Refactor ethernet routines

### DIFF
--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -22,7 +22,7 @@ def test_addr_tree_digest():
     assert f"eth.{direction}_resolved" in tree_digest
     assert tree_digest["eth.addr"] == addr
 
-    oui = str(ethernet.oui_from_hex_addr(addr))
+    oui = str(ethernet.EthAddr(addr).oui)
     assert tree_digest["eth.addr.oui"] == oui
 
     assert tree_digest["eth.addr.oui_resolved"] == "Randomized"

--- a/tests/test_ethernet.py
+++ b/tests/test_ethernet.py
@@ -28,7 +28,7 @@ def test_eth_addr():
 
 def test_eth_addr_formats():
     """Test possible formats to initialize the EthAddr class."""
-    components = ("ed", "b7", "2f", "d1", "78", "80", "27, ab")
+    components = ("ed", "b7", "2f", "d1", "78", "80", "27", "ab")
     addr_len = ethernet.EthAddr.ETH_ADDR_BYTE_LEN
 
     for good_sep in [":", ".", ""]:
@@ -59,7 +59,7 @@ def test_eth_addr_formats():
 
 def test_addr_scope():
     """Test EthAddr is_local and is_group properties."""
-    addr_end = ":".join(("ed", "b7", "2f", "d1", "78", "80", "27, ab")[1:6])
+    addr_end = ":".join(("ed", "b7", "2f", "d1", "78", "80", "27", "ab")[1:6])
     for byte0 in range(256):
         addr = ethernet.EthAddr(f"{byte0:02x}:{addr_end}")
         assert bool(byte0 & ethernet.EthAddr.LOCAL_MASK) == addr.is_local

--- a/tests/test_ethernet.py
+++ b/tests/test_ethernet.py
@@ -1,3 +1,6 @@
+"""Test routines in the ethernet module."""
+
+from contextlib import nullcontext as does_not_raise
 import itertools
 import re
 
@@ -10,21 +13,69 @@ HEX_ETH_ADDR_FIRST_BYTE = re.compile(
 )
 
 
+def test_eth_addr():
+    """Test the EthAddr class with overall tests."""
+    sample_address = "ed:b7:2f:d1:78:80"
+    addr = ethernet.EthAddr(sample_address)
+    assert addr.human_friendly_form == sample_address
+    assert str(addr) == sample_address
+    assert addr.normalized == b"\xed\xb7\x2f\xd1\x78\x80"
+    assert addr.is_local
+    assert not addr.is_group
+    assert addr.oui == 15578927
+    assert addr.nic == 13727872
+
+
+def test_eth_addr_formats():
+    """Test possible formats to initialize the EthAddr class."""
+    components = ("ed", "b7", "2f", "d1", "78", "80", "27, ab")
+    addr_len = ethernet.EthAddr.ETH_ADDR_BYTE_LEN
+
+    for good_sep in [":", ".", ""]:
+        with does_not_raise():
+            well_formed_addr = good_sep.join(components[:addr_len])
+            ethernet.EthAddr(well_formed_addr)
+
+    for bad_sep in [",", "*"]:
+        with pytest.raises(ethernet.UnrecognizedEthernetAddressFormat):
+            poorly_formed_addr = bad_sep.join(components[:addr_len])
+            ethernet.EthAddr(poorly_formed_addr)
+
+    for i in range(len(components)):
+        if i == addr_len:
+            expectation = does_not_raise()
+        else:
+            expectation = pytest.raises(ethernet.UnrecognizedEthernetAddressFormat)
+
+        with expectation:
+            ethernet.EthAddr(":".join(components[:i]))
+
+    bad_components = ["&x", "123", "ab3", "AB", "1A", "na", "an", "a", ""]
+    for i, bad_component in itertools.product(range(addr_len), bad_components):
+        mixed_components = components[:i] + tuple(bad_components) + components[i + 1 :]
+        with pytest.raises(ethernet.UnrecognizedEthernetAddressFormat):
+            ethernet.EthAddr(":".join(mixed_components))
+
+
+def test_addr_scope():
+    """Test EthAddr is_local and is_group properties."""
+    addr_end = ":".join(("ed", "b7", "2f", "d1", "78", "80", "27, ab")[1:6])
+    for byte0 in range(256):
+        addr = ethernet.EthAddr(f"{byte0:02x}:{addr_end}")
+        assert bool(byte0 & ethernet.EthAddr.LOCAL_MASK) == addr.is_local
+        assert bool(byte0 & ethernet.EthAddr.GROUP_MASK) == addr.is_group
+
+
 @pytest.mark.parametrize(
-    "local, group, test_repeats",
-    itertools.product([True, False], [True, False], range(5)),
+    "local, group",
+    itertools.product([True, False], [True, False]),
 )
-def test_random_eth_addr(local, group, test_repeats):
-    """Test the random_eth_addr routine."""
-    addr = ethernet.random_eth_addr(local, group)
-
-    addr_match = HEX_ETH_ADDR_FIRST_BYTE.match(addr)
-    assert addr_match
-
-    [byte0] = addr_match.groups()
-    byte0 = int(byte0, base=16)
-    assert byte0 & ethernet.LOCAL_MASK == local * ethernet.LOCAL_MASK
-    assert byte0 & ethernet.GROUP_MASK == group * ethernet.GROUP_MASK
+def test_random_eth_addr(local, group):
+    """Test EthAddr's random_eth_addr routine."""
+    for _test_ind in range(100):
+        addr = ethernet.EthAddr.random_eth_addr(local, group)
+        assert addr.is_local == local
+        assert addr.is_group == group
 
 
 @pytest.mark.parametrize(
@@ -35,6 +86,6 @@ def test_random_eth_addr(local, group, test_repeats):
         ("ff:ff:ff:00:00:00", 16777215),
     ],
 )
-def test_oui_from_hex_addr(addr, oui):
-    """Test the oui_from_hex_addr routine."""
-    assert ethernet.oui_from_hex_addr(addr) == oui
+def test_eth_addr_oui(addr, oui):
+    """Test the oui property of EthAddr."""
+    assert ethernet.EthAddr(addr).oui == oui

--- a/wireshark_digest_to_sqlite/anonymize.py
+++ b/wireshark_digest_to_sqlite/anonymize.py
@@ -8,21 +8,22 @@ import pathlib
 from wireshark_digest_to_sqlite import ethernet
 
 
-def addr_tree_digest(addr, direction):
+def addr_tree_digest(addr_for_tree, direction):
     """
     Return the wireshark digest tree for an address. The oui values resolve
     to `Randomized`.
     """
-    oui = f"{ethernet.oui_from_hex_addr(addr):d}"
+    addr = ethernet.EthAddr(addr_for_tree)
+    oui = f"{addr.oui:d}"
     OUI_RESOLVED = "Randomized"
-    local = f"{ethernet.is_local(addr):d}"  # `True` becomes "1"
-    group = f"{ethernet.is_group(addr):d}"
+    local = f"{addr.is_local:d}"  # `True` becomes "1"
+    group = f"{addr.is_group:d}"
     return {
-        f"eth.{direction}_resolved": addr,
+        f"eth.{direction}_resolved": addr_for_tree,
         f"eth.{direction}.oui": oui,
         f"eth.{direction}.oui_resolved": OUI_RESOLVED,
-        "eth.addr": addr,
-        "eth.addr_resolved": addr,
+        "eth.addr": addr_for_tree,
+        "eth.addr_resolved": addr_for_tree,
         "eth.addr.oui": oui,
         "eth.addr.oui_resolved": OUI_RESOLVED,
         f"eth.{direction}.lg": local,
@@ -48,7 +49,7 @@ def randomize_ethernet_addresses(digest):
             if not og_addr:
                 continue
             anon_addr = replaced.setdefault(
-                og_addr, ethernet.random_eth_addr(local=True, group=False)
+                og_addr, str(ethernet.EthAddr.random_eth_addr(local=True, group=False))
             )
             eth_layer[f"eth.{direction}"] = anon_addr
             anon_addr_tree = addr_tree_digest(anon_addr, direction)

--- a/wireshark_digest_to_sqlite/ethernet.py
+++ b/wireshark_digest_to_sqlite/ethernet.py
@@ -1,3 +1,7 @@
+"""Provide capabilities to parse ethernet addresses and generate random ones
+to specification."""
+
+import re
 import secrets
 
 
@@ -25,51 +29,103 @@ def set_mask_bits(val, mask, on):
 
 
 BITS_PER_BYTE = 8
-LOCAL_MASK = 0x01
-GROUP_MASK = 0x02
-ETH_ADDR_BYTE_LEN = 6
 
 
-def random_eth_addr(local=False, group=False):
-    """
-    Generate a random ethernet address in colon-separated hex notation.
-    Arguments set if the address is local or not and group or unicast.
-    """
-    first_byte = set_mask_bits(secrets.randbits(BITS_PER_BYTE), LOCAL_MASK, local)
-    first_byte = set_mask_bits(first_byte, GROUP_MASK, group)
-
-    first_byte = bytes([first_byte])
-    addr = first_byte + secrets.token_bytes(ETH_ADDR_BYTE_LEN - 1)
-    return addr.hex(":")
+class UnrecognizedEthernetAddressFormat(Exception):
+    """Raise when unable to parse human readable form of an ethernet address."""
 
 
-OUI_BYTES = 3
+class EthAddr:
+    OUI_BYTES = 3
+    LOCAL_MASK = 0x01
+    GROUP_MASK = 0x02
+    ETH_ADDR_BYTE_LEN = 6
 
+    HEX_ETH_ADDR_FORMATS = tuple(
+        re.compile(
+            rf"""
+                ^
+                ([a-z0-9]{{2}})      
+                {sep}([a-z0-9]{{2}}) 
+                {sep}([a-z0-9]{{2}}) 
+                {sep}([a-z0-9]{{2}}) 
+                {sep}([a-z0-9]{{2}}) 
+                {sep}([a-z0-9]{{2}}) 
+                $
+            """,
+            flags=re.IGNORECASE | re.VERBOSE,
+        )
+        # `:` format used by wireshark, for example
+        # `.` format used by IEEE 802, for example
+        for sep in [":", "\.", ""]
+    )
 
-def is_local(addr):
-    """
-    Returns if an ethernet address is a local address instead of a universal
-    one.
-    """
-    first_byte, _others = addr.split(":", maxsplit=1)
-    first_byte = int(first_byte, base=16)
-    return bool(first_byte & LOCAL_MASK)
+    def __init__(self, human_friendly_form):
+        match_attempts = [
+            addr_format.match(human_friendly_form)
+            for addr_format in self.HEX_ETH_ADDR_FORMATS
+        ]
 
+        try:
+            [success_match] = [
+                addr_match for addr_match in match_attempts if addr_match
+            ]
+        except ValueError:
+            raise UnrecognizedEthernetAddressFormat(
+                "Didn't find six hex components in human readable format: "
+                f"`{human_friendly_form}`."
+            )
 
-def is_group(addr):
-    """
-    Returns if an ethernet address is a group address instead of an individual
-    one.
-    """
-    first_byte, _others = addr.split(":", maxsplit=1)
-    first_byte = int(first_byte, base=16)
-    return bool(first_byte & GROUP_MASK)
+        self.normalized = bytes.fromhex("".join(success_match.groups()))
+        self.human_friendly_form = human_friendly_form
 
+    @property
+    def is_local(self):
+        """
+        Returns if an ethernet address is a local address instead of a universal
+        one.
+        """
+        return bool(self.normalized[0] & self.LOCAL_MASK)
 
-def oui_from_hex_addr(addr):
-    """
-    Return the organizationally unique identifier of a universal ethernet
-    address.
-    """
-    oui_hex = "".join(addr.split(":")[:OUI_BYTES])
-    return int(oui_hex, base=16)
+    @property
+    def is_group(self):
+        """
+        Returns if an ethernet address is a group address instead of an individual
+        one.
+        """
+        return bool(self.normalized[0] & self.GROUP_MASK)
+
+    @property
+    def oui(self):
+        """
+        Return the organizationally unique identifier of a universal ethernet
+        address.
+        """
+        return int.from_bytes(self.normalized[: self.OUI_BYTES], byteorder="big")
+
+    @property
+    def nic(self):
+        """
+        Return the network interface controller specfic part of a universal
+        ethernet address.
+        """
+        return int.from_bytes(self.normalized[self.OUI_BYTES :], byteorder="big")
+
+    @classmethod
+    def random_eth_addr(cls, local=False, group=False):
+        """
+        Generate a random ethernet address in colon-separated hex notation.
+        Arguments set if the address is local or not and group or unicast.
+        """
+        first_byte = set_mask_bits(
+            secrets.randbits(BITS_PER_BYTE), cls.LOCAL_MASK, local
+        )
+        first_byte = set_mask_bits(first_byte, cls.GROUP_MASK, group)
+
+        first_byte = bytes([first_byte])
+        addr = first_byte + secrets.token_bytes(cls.ETH_ADDR_BYTE_LEN - 1)
+        return cls(addr.hex(":"))
+
+    def __repr__(self):
+        """Return the human readable form of an ethernet address."""
+        return self.human_friendly_form


### PR DESCRIPTION
The ethernet layer requires detailed handling because the anonymize routines make heavy use of it. Refactor the ethernet functions into a class with methods to improve code and for readability.  