### PR TITLE
Add utility functions for working with nested json objects in python

### DIFF
--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,184 @@
+"""Test routines from the digest module."""
+
+import json
+from collections.abc import Iterable
+
+import pytest
+
+from wireshark_digest_to_sqlite import digest
+
+
+@pytest.fixture
+def sample_json():
+    return json.loads(
+        """
+        {
+          "string": "Hello, world!",
+          "number": 42,
+          "boolean": true,
+          "null": null,
+          "array": [
+            1,
+            "two",
+            false,
+            null,
+            [3, 4, 5],
+            {"nestedKey": "nestedValue"}
+          ],
+          "object": {
+            "key1": "value1",
+            "key2": 2,
+            "nestedArray": [6, 7, 8],
+            "nestedObject": {
+              "innerKey1": "innerValue1",
+              "innerKey2": 9
+            }
+          }
+        }
+        """
+    )
+
+
+@pytest.mark.parametrize(
+    "json_primitive,expected_nodes",
+    [
+        ("Hello, world!", ["Hello, world!"]),
+        (42, [42]),
+        (True, [True]),
+        (None, [None]),
+        ([3, 4, 5], [3, 4, 5]),
+        ({"key1": "value1", "key2": "value2"}, ["value1", "value2"]),
+    ],
+)
+def test_nodes_with_json_primitives(json_primitive, expected_nodes):
+    """Test the nodes routine with JSON primitives."""
+    assert list(digest.nodes(json_primitive)) == expected_nodes
+
+
+def test_nodes(sample_json):
+    """Test the nodes routine with combinations of JSON primitives."""
+    sample_array = sample_json["array"]
+    expected_nodes = [1, "two", False, None, 3, 4, 5, "nestedValue"]
+    assert list(digest.nodes(sample_array)) == expected_nodes
+
+    sample_dict = sample_json["object"]
+    assert list(digest.nodes(sample_dict)) == ["value1", 2, 6, 7, 8, "innerValue1", 9]
+
+    nodes_from_top = ["Hello, world!", 42, True, None]
+    nodes_from_array = list(digest.nodes(sample_array))
+    nodes_from_dict = list(digest.nodes(sample_dict))
+    expected_nodes = nodes_from_top + nodes_from_array + nodes_from_dict
+    assert list(digest.nodes(sample_json)) == expected_nodes
+
+    assert isinstance(digest.nodes(sample_json), Iterable)
+
+
+@pytest.mark.parametrize(
+    "json_primitive,expected_labels",
+    [
+        ("Hello, world!", list()),
+        (42, list()),
+        (True, list()),
+        (None, list()),
+        ([3, 4, 5], list()),
+        ({"key1": "value1", "key2": "value2"}, ["key1", "key2"]),
+    ],
+)
+def test_labels_with_json_primitives(json_primitive, expected_labels):
+    """Test the labels routine with JSON primitives."""
+    assert list(digest.labels(json_primitive)) == expected_labels
+
+
+def test_labels(sample_json):
+    """Test the labels routine with combinations of JSON primitives."""
+    sample_array = sample_json["array"]
+    assert list(digest.labels(sample_array)) == ["nestedKey"]
+
+    sample_dict = sample_json["object"]
+    top_level_lables = list(sample_dict.keys())
+    lower_level_labels = list(sample_dict["nestedObject"].keys())
+    assert list(digest.labels(sample_dict)) == top_level_lables + lower_level_labels
+
+    labels_from_top = list(sample_json.keys())
+    labels_from_array = list(digest.labels(sample_array))
+    labels_from_dict = list(digest.labels(sample_dict))
+    expected_labels = labels_from_top + labels_from_array + labels_from_dict
+    assert sorted(list(digest.labels(sample_json))) == sorted(expected_labels)
+
+    assert isinstance(digest.labels(sample_json), Iterable)
+
+
+def test_JsonObject(sample_json):
+    """Test the JsonObject class."""
+    sample_obj = digest.JsonObject(key1="value1", key2="value2")
+    assert sample_obj.key1 == "value1"
+    assert sample_obj.key2 == "value2"
+
+    sample_obj_same = digest.JsonObject(key2="value2", key1="value1")
+    assert sample_obj == sample_obj_same
+    sample_obj_diff = digest.JsonObject(key1="value2", key2="value2")
+    assert sample_obj != sample_obj_diff
+    sample_obj_diff = digest.JsonObject(key1="value1")
+    assert sample_obj != sample_obj_diff
+    sample_obj = digest.JsonObject(key3="value1", key2="value2")
+    assert sample_obj != sample_obj_diff
+
+
+    sample_dict = sample_json["object"]
+    json_obj = digest.JsonObject(**sample_dict)
+    for key, value in sample_dict.items():
+        assert getattr(json_obj, key) == value
+
+    from_dict_obj = digest.JsonObject.from_dict(sample_dict)
+    assert from_dict_obj == json_obj
+
+    sample_raw = json.dumps(sample_json)
+    sample_json_obj = json.loads(
+        sample_raw, object_hook=lambda x: digest.JsonObject(**x)
+    )
+    assert isinstance(sample_json_obj, digest.JsonObject)
+    assert sample_json_obj.string == sample_json["string"]
+    assert sample_json_obj.number == sample_json["number"]
+    assert isinstance(sample_json_obj.object, digest.JsonObject)
+    assert sample_json_obj.object.key1 == sample_dict["key1"]
+    innerKey1_val = sample_dict["nestedObject"]["innerKey1"]
+    assert sample_json_obj.object.nestedObject.innerKey1 == innerKey1_val
+
+
+def test_promote_named_objects(sample_json):
+    """Test the promote_named_objects routine."""
+
+    class ExampleJsonObjectClass(digest.JsonObject):
+        def __init__(self, /, **kwargs):
+            super().__init__(**kwargs)
+            self.keynum = len(self.__dict__.keys()) - 1
+
+    sample_obj_map = {
+        "object": ExampleJsonObjectClass,
+        "array": ExampleJsonObjectClass,
+        "nestedObject": digest.JsonObject,
+    }
+
+    sample_raw = json.dumps(sample_json)
+    sample_json_obj = json.loads(
+        sample_raw,
+        object_hook=lambda x: digest.promote_named_objects(x, sample_obj_map),
+    )
+
+    assert isinstance(sample_json_obj, digest.JsonObject)
+    assert not isinstance(sample_json_obj, ExampleJsonObjectClass)
+
+    assert isinstance(sample_json_obj.object, digest.JsonObject)
+    assert isinstance(sample_json_obj.object, ExampleJsonObjectClass)
+    assert hasattr(sample_json_obj.object, "keynum")
+    sample_dict = sample_json["object"]
+    innerKey1_val = sample_dict["nestedObject"]["innerKey1"]
+    assert sample_json_obj.object.nestedObject.innerKey1 == innerKey1_val
+
+    sample_array = sample_json["array"]
+    for i, value in enumerate(sample_array):
+        if isinstance(value, dict):
+            should_be_promoted = sample_json_obj.array[i]
+            assert isinstance(should_be_promoted, ExampleJsonObjectClass)
+        else:
+            assert sample_array[i] == sample_json_obj.array[i]

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,5 +1,6 @@
 """Test routines from the digest module."""
 
+import functools
 import json
 from collections.abc import Iterable
 
@@ -10,6 +11,7 @@ from wireshark_digest_to_sqlite import digest
 
 @pytest.fixture
 def sample_json():
+    """Return a sample json with nested primitives."""
     return json.loads(
         """
         {
@@ -108,34 +110,38 @@ def test_labels(sample_json):
     assert isinstance(digest.labels(sample_json), Iterable)
 
 
+def test_strip_matching_prefix():
+    """Test the strip_matching_prefix routine."""
+    assert digest.strip_matching_prefix("prefix.abc", "prefix.123") == "abc"
+    assert digest.strip_matching_prefix("abc", "") == "abc"
+    assert digest.strip_matching_prefix("abc", "123") == "abc"
+    assert digest.strip_matching_prefix("", "123") == ""
+    assert digest.strip_matching_prefix("abc.suffix", "123.suffix") == "abc.suffix"
+
+
 def test_JsonObject(sample_json):
     """Test the JsonObject class."""
-    sample_obj = digest.JsonObject(key1="value1", key2="value2")
+    sample_dict = {"key1": "value1", "key2": "value2"}
+    sample_obj = digest.JsonObject(sample_dict)
     assert sample_obj.key1 == "value1"
     assert sample_obj.key2 == "value2"
 
-    sample_obj_same = digest.JsonObject(key2="value2", key1="value1")
+    sample_obj_same = digest.JsonObject({"key2": "value2", "key1": "value1"})
     assert sample_obj == sample_obj_same
-    sample_obj_diff = digest.JsonObject(key1="value2", key2="value2")
+    sample_obj_diff = digest.JsonObject({"key1": "value2", "key2": "value2"})
     assert sample_obj != sample_obj_diff
-    sample_obj_diff = digest.JsonObject(key1="value1")
+    sample_obj_diff = digest.JsonObject({"key1": "value1"})
     assert sample_obj != sample_obj_diff
-    sample_obj = digest.JsonObject(key3="value1", key2="value2")
+    sample_obj = digest.JsonObject({"key3": "value1", "key2": "value2"})
     assert sample_obj != sample_obj_diff
-
 
     sample_dict = sample_json["object"]
-    json_obj = digest.JsonObject(**sample_dict)
+    json_obj = digest.JsonObject(sample_dict)
     for key, value in sample_dict.items():
         assert getattr(json_obj, key) == value
 
-    from_dict_obj = digest.JsonObject.from_dict(sample_dict)
-    assert from_dict_obj == json_obj
-
     sample_raw = json.dumps(sample_json)
-    sample_json_obj = json.loads(
-        sample_raw, object_hook=lambda x: digest.JsonObject(**x)
-    )
+    sample_json_obj = json.loads(sample_raw, object_hook=digest.JsonObject)
     assert isinstance(sample_json_obj, digest.JsonObject)
     assert sample_json_obj.string == sample_json["string"]
     assert sample_json_obj.number == sample_json["number"]
@@ -144,13 +150,35 @@ def test_JsonObject(sample_json):
     innerKey1_val = sample_dict["nestedObject"]["innerKey1"]
     assert sample_json_obj.object.nestedObject.innerKey1 == innerKey1_val
 
+    # overly complex to illustrate the scenario for strip_prefixes.
+    sample_dict = {
+        "a": {"a.key1": "value1", "a.key2": "value2"},
+    }
+
+    class SampleObj(digest.JsonObject):
+        def first_key(self):
+            first, *others = sorted(self._json_raw.keys())
+            return first
+
+    obj = digest.JsonObject(sample_dict["a"])
+
+    promoted = obj.promote(SampleObj)
+    assert isinstance(promoted, SampleObj)
+    assert hasattr(promoted, "a.key2")
+    assert promoted.first_key() == "a.key1"
+
+    promoted = obj.promote(SampleObj, val_for_prefix_strip="a.")
+    assert isinstance(promoted, SampleObj)
+    assert hasattr(promoted, "key2")
+    assert promoted.first_key() == "key1"
+
 
 def test_promote_named_objects(sample_json):
     """Test the promote_named_objects routine."""
 
     class ExampleJsonObjectClass(digest.JsonObject):
-        def __init__(self, /, **kwargs):
-            super().__init__(**kwargs)
+        def __init__(self, obj_dict):
+            super().__init__(obj_dict)
             self.keynum = len(self.__dict__.keys()) - 1
 
     sample_obj_map = {
@@ -159,10 +187,14 @@ def test_promote_named_objects(sample_json):
         "nestedObject": digest.JsonObject,
     }
 
+    promote_sample_objects = functools.partial(
+        digest.promote_named_objects, object_map=sample_obj_map
+    )
+
     sample_raw = json.dumps(sample_json)
     sample_json_obj = json.loads(
         sample_raw,
-        object_hook=lambda x: digest.promote_named_objects(x, sample_obj_map),
+        object_hook=promote_sample_objects,
     )
 
     assert isinstance(sample_json_obj, digest.JsonObject)
@@ -182,3 +214,87 @@ def test_promote_named_objects(sample_json):
             assert isinstance(should_be_promoted, ExampleJsonObjectClass)
         else:
             assert sample_array[i] == sample_json_obj.array[i]
+
+    class SampleObj(digest.JsonObject):
+        def first_key(self):
+            first, *others = sorted(self._json_raw.keys())
+            return first
+
+    sample_dict = {
+        "a": {"a.key1": "value1", "a.key2": "value2"},
+    }
+    sample_raw = json.dumps(sample_dict)
+    sample_json_obj = json.loads(
+        sample_raw,
+        object_hook=lambda x: digest.promote_named_objects(
+            x, {"a": SampleObj}, keep_dots=False, strip_prefixes=True
+        ),
+    )
+    assert hasattr(sample_json_obj.a, "key1")
+    sample_json_obj = json.loads(
+        sample_raw,
+        object_hook=lambda x: digest.promote_named_objects(
+            x, {"a": SampleObj}, keep_dots=True, strip_prefixes=False
+        ),
+    )
+    assert hasattr(sample_json_obj.a, "a.key1")
+    sample_json_obj = json.loads(
+        sample_raw,
+        object_hook=lambda x: digest.promote_named_objects(
+            x, {"a": SampleObj}, keep_dots=False, strip_prefixes=False
+        ),
+    )
+    assert hasattr(sample_json_obj.a, "a_key1")
+
+
+def test_promote_named_objects_on_pcap_data(sample_digest):
+    """Test the promote_named_objects routine to model a use case with pcaps."""
+
+    class Frame(digest.JsonObject):
+        @property
+        def highest_protocol(self):
+            *lower_protos, highest_proto = self.protocols.split(":")
+            return highest_proto
+
+    class Packet(digest.JsonObject):
+        @property
+        def tcp_five_tuple(self):
+            try:
+                ip = self._source.layers.ip
+                tcp = self._source.layers.tcp
+            except AttributeError:
+                connection = None
+            else:
+                connection = (ip.src, tcp.srcport, ip.dst, tcp.dstport, "tcp")
+            return connection
+
+    class_map = {"frame": Frame}
+    promote_frames = functools.partial(
+        digest.promote_named_objects,
+        object_map=class_map,
+        keep_dots=False,
+        strip_prefixes=True,
+    )
+
+    raw_digest = json.dumps(sample_digest)
+    digest_reloaded = json.loads(
+        raw_digest,
+        object_hook=promote_frames,
+    )
+
+    packets = [obj.promote(Packet) for obj in digest_reloaded]
+
+    expected_protos = sample_digest[0]["_source"]["layers"]["frame"]["frame.protocols"]
+    expected_highest = expected_protos.split(":")[-1]
+    assert packets[0]._source.layers.frame.highest_protocol == expected_highest
+
+    expected_ip = sample_digest[0]["_source"]["layers"]["ip"]
+    expected_tcp = sample_digest[0]["_source"]["layers"]["tcp"]
+    expected_five_tuple = (
+        expected_ip["ip.src"],
+        expected_tcp["tcp.srcport"],
+        expected_ip["ip.dst"],
+        expected_tcp["tcp.dstport"],
+        "tcp",
+    )
+    assert packets[0].tcp_five_tuple == expected_five_tuple

--- a/wireshark_digest_to_sqlite/digest.py
+++ b/wireshark_digest_to_sqlite/digest.py
@@ -1,0 +1,91 @@
+"""Provide utility functions for working with deeply nested JSONs."""
+
+def nodes(json_data):
+    """Return iterable of all leaf nodes (non-dict and non-array) in a JSON."""
+    to_visit = None
+    if isinstance(json_data, list):
+        to_visit = json_data
+    elif isinstance(json_data, dict):
+        to_visit = json_data.values()
+
+    if to_visit:
+        for value in to_visit:
+            yield from nodes(value)
+    else:
+        yield json_data
+
+
+def labels(json_data):
+    """Return iterable of the labels (dictionary keys) at any level in a JSON."""
+    if isinstance(json_data, list):
+        for value in json_data:
+            yield from labels(value)
+    elif isinstance(json_data, dict):
+        for key, value in json_data.items():
+            yield key
+            yield from labels(value)
+    else:
+        pass
+
+
+class JsonObject:
+    """Provide alternative to dict in reading JSON objects.
+    
+    When reading or loading a JSON object, use this as an alternative to dicts
+    to be able to access values through attributes instead of keys. Can be used
+    with `object_hook` for json.load.
+
+    Subclass this for "types" of objects (e.g. an array of JSON objects of
+    similar structure) that may require additional processing, attributes, or
+    methods. 
+    """
+    def __init__(self, /, **kwargs):
+        """Provide each attribute as a keyword argument."""
+        self.__dict__.update(kwargs)
+        self._json_raw = kwargs
+
+    
+    @classmethod
+    def from_dict(cls, dictionary):
+        """Construct from a dict instead of keywords."""
+        return cls(**dictionary)
+
+    def __repr__(self):
+        """Return a string with the defining key/value pairs."""
+        item_descriptions = (
+            f"{key}={value}"
+            for key, value in self.__dict__.items()
+            if key != "_json_raw"
+        )
+        joined_item_descriptions = f"{', '.join(item_descriptions)}"
+
+        name_description = f"{type(self).__name__}"
+
+        return f"{name_description}({joined_item_descriptions})"
+
+    def __eq__(self, other):
+        """Return if self has the same defining key/value pairs as other."""
+        return self._json_raw == other._json_raw
+
+
+def promote_named_objects(obj, object_map):
+    """Convert JsonObjects to new classes by key names.
+
+    For each label in obj that is in object_map, promote the value(s) at key
+    from the generic JsonObject to the class identified by object_map. Then
+    return JsonObject(obj). Can be used with `object_hook` when loading JSON.
+    """
+    for key, preprocessed in obj.items():
+        promo_cls = object_map.get(key)
+        if not promo_cls:
+            pass
+        elif isinstance(preprocessed, JsonObject):
+            obj[key] = promo_cls(**preprocessed._json_raw)
+        elif isinstance(preprocessed, list):
+            obj[key] = [
+                promo_cls(**entry._json_raw) if isinstance(entry, JsonObject) else entry
+                for entry in preprocessed
+            ]
+        else:
+            pass
+    return JsonObject(**obj)

--- a/wireshark_digest_to_sqlite/digest.py
+++ b/wireshark_digest_to_sqlite/digest.py
@@ -1,5 +1,8 @@
 """Provide utility functions for working with deeply nested JSONs."""
 
+import itertools
+
+
 def nodes(json_data):
     """Return iterable of all leaf nodes (non-dict and non-array) in a JSON."""
     to_visit = None
@@ -28,27 +31,32 @@ def labels(json_data):
         pass
 
 
+def strip_matching_prefix(to_strip, to_match_prefix):
+    """Return to_strip with any shared prefix of to_match_prefix removed."""
+    letter_pairs = zip(to_strip, to_match_prefix)
+    iterate_to_no_match = itertools.takewhile(
+        lambda pair: pair[0] == pair[1], letter_pairs
+    )
+    matching_prefix = "".join(pair[0] for pair in iterate_to_no_match)
+    return to_strip.removeprefix(matching_prefix)
+
+
 class JsonObject:
     """Provide alternative to dict in reading JSON objects.
-    
+
     When reading or loading a JSON object, use this as an alternative to dicts
     to be able to access values through attributes instead of keys. Can be used
     with `object_hook` for json.load.
 
     Subclass this for "types" of objects (e.g. an array of JSON objects of
     similar structure) that may require additional processing, attributes, or
-    methods. 
+    methods.
     """
-    def __init__(self, /, **kwargs):
-        """Provide each attribute as a keyword argument."""
-        self.__dict__.update(kwargs)
-        self._json_raw = kwargs
 
-    
-    @classmethod
-    def from_dict(cls, dictionary):
-        """Construct from a dict instead of keywords."""
-        return cls(**dictionary)
+    def __init__(self, obj_dict):
+        """Initialize with a dict of attribute, value pairs."""
+        self.__dict__.update(obj_dict)
+        self._json_raw = obj_dict
 
     def __repr__(self):
         """Return a string with the defining key/value pairs."""
@@ -67,25 +75,63 @@ class JsonObject:
         """Return if self has the same defining key/value pairs as other."""
         return self._json_raw == other._json_raw
 
+    def promote(self, subclass, val_for_prefix_strip=None):
+        """Return a subclass instance formed from the original input to self.
 
-def promote_named_objects(obj, object_map):
+        Return a subclass instance created by calling the subclass.__init__ on
+        the argument this self was initialized with. In some use cases, the
+        keys of the original data need to be renamed such that a common prefix
+        of those keys is removed.
+        """
+        if val_for_prefix_strip:
+            promoted = subclass(
+                {
+                    strip_matching_prefix(key, val_for_prefix_strip): value
+                    for key, value in self._json_raw.items()
+                }
+            )
+        else:
+            promoted = subclass(self._json_raw)
+        return promoted
+
+
+def promote_named_objects(obj, object_map, keep_dots=False, strip_prefixes=False):
     """Convert JsonObjects to new classes by key names.
 
     For each label in obj that is in object_map, promote the value(s) at key
     from the generic JsonObject to the class identified by object_map. Then
     return JsonObject(obj). Can be used with `object_hook` when loading JSON.
+    See testing of this function for an example that avoids lambda functions by
+    using functools.partial to provide the object_map.
+
+    Keys with '.'s are inconvenient because they cannot be accessed directly as
+    attributes (see object.a.b vs getattr(object, "a.b")). When keep_dots is
+    False, '.'s in keys are replaced with '_'s.
+
+    A common use case with nested json objects carries the key name for an
+    object into the keys of the object itself. To automatically remove this
+    redundancy, use the strip_prefixes option.
     """
+    # can't rename keys mid for-loop so need a destination for the changes
+    dst_obj = dict()
+
     for key, preprocessed in obj.items():
-        promo_cls = object_map.get(key)
-        if not promo_cls:
-            pass
-        elif isinstance(preprocessed, JsonObject):
-            obj[key] = promo_cls(**preprocessed._json_raw)
+        promo_cls = object_map.get(key, JsonObject)
+        delimeter = "." if keep_dots else "_"
+        new_key = key if keep_dots else key.replace(".", "_")
+        strip_key = f"{new_key}{delimeter}" if strip_prefixes else None
+        if isinstance(preprocessed, JsonObject):
+            reprocessed = preprocessed.promote(promo_cls, strip_key)
         elif isinstance(preprocessed, list):
-            obj[key] = [
-                promo_cls(**entry._json_raw) if isinstance(entry, JsonObject) else entry
+            reprocessed = [
+                (
+                    entry.promote(promo_cls, strip_key)
+                    if isinstance(entry, JsonObject)
+                    else entry
+                )
                 for entry in preprocessed
             ]
         else:
-            pass
-    return JsonObject(**obj)
+            reprocessed = preprocessed
+        dst_obj[new_key] = reprocessed
+    return JsonObject(dst_obj)


### PR DESCRIPTION
Wireshark protocol dissections exported as a json can be deeply nested. These routines provide convenient ways to iterate through dissections and ways to treat them as convenient Python objects. 