### PR TITLE
Add ruff format github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
       contents: write
 
     steps:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,5 +20,4 @@ jobs:
         src: ./
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: 'style fixes by ruff'
-
+        commit_message: 'Add automated style fixes by ruff'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,6 @@ jobs:
       with:
         args: format
         src: ./
-        config: .pyproject.toml
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: 'style fixes by ruff'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,25 @@
+name: Push Workflow - Format
+
+on:
+  push:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: chartboost/ruff-action@v1
+      with:
+        args: format
+        src: ./
+        config: .pyproject.toml
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: 'style fixes by ruff'
+

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,6 +1,4 @@
-#This workflow installs Python dependencies, tests, and lints.
-
-name: Python application
+name: Pull Workflow - Test and lint
 
 on:
   pull_request:
@@ -9,7 +7,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  validate:
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ Create a SQLite database of the Wireshark digests from a packet capture.
 For your convenience, a pre-commit configuration file is included in this
 project which formats and lints. To install, follow the instructions at
 [https://pre-commit.com](https://pre-commit.com/#quick-start). 
+
+This project uses the `ruff` for formatting. A Github action automatically
+applies `ruff format` on pull requests and any changes are committed on top of
+the request.  If not pre-formatting before submitting a pull request, make sure
+to bring back any formatting changes automatically applied to origin.


### PR DESCRIPTION
Add action to apply ruff formatting to code when it is pushed as an automatic commit. If no formatting is needed, there is no extra commit. Note that contributors should fetch when they push to obtain any automatically applied commits of this kind from the remote - if not using `ruff format` locally before pushing (e.g. with the project's pre-commit hooks).